### PR TITLE
Update Info.plist

### DIFF
--- a/ios/NfcOpenReader/Info.plist
+++ b/ios/NfcOpenReader/Info.plist
@@ -85,6 +85,17 @@
 		<string>D2760000850100</string>
 		<string>D2760000850101</string>
 	</array>
+	<key>com.apple.developer.nfc.readersession.felica.systemcodes</key>
+	<array>
+		<string>8005</string>
+		<string>8008</string>
+		<string>0003</string>
+		<string>fe00</string>
+		<string>90b7</string>
+		<string>927a</string>
+		<string>12FC</string>
+		<string>86a7</string>
+	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>


### PR DESCRIPTION
Added support for FelicaIOS , the app crash if you use NfcTech.FelicaIOS because the key: com.apple.developer.nfc.readersession.felica.systemcodes is missing in Info.plist